### PR TITLE
Use "long-timeout" module instead of our own implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nino",
   "description": "Moderation bot for Discord's hack week entry.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://nino.augu.dev",
   "license": "MIT",
   "repository": "https://github.com/NinoDiscord/Nino",
@@ -39,6 +39,7 @@
     "ioredis": "4.17.3",
     "js-yaml": "3.14.0",
     "leeks.js": "0.0.8",
+    "long-timeout": "0.1.1",
     "mongoose": "5.9.27",
     "ms": "2.1.2",
     "reflect-metadata": "0.1.13",

--- a/src/@types/long-timeout.d.ts
+++ b/src/@types/long-timeout.d.ts
@@ -1,0 +1,41 @@
+// Definitions for package: "long-timeout"
+// Project: https://github.com/tellnes/long-timeout
+// Definitions by:
+//    - August (Chris) <https://github.com/auguwu>
+
+declare module 'long-timeout' {
+  namespace LongTimeout {
+    export function setTimeout(listener: (...args: any[]) => void, after: number): LongTimeout.Timeout;
+    export function setInterval(listener: (...args: any[]) => void, after: number): LongTimeout.Interval;
+    export function clearTimeout(timer: LongTimeout.Timeout): void;
+    export function clearInterval(interval: LongTimeout.Interval): void;
+
+    export class Timeout {
+      constructor(listener: (...args: any[]) => void, after: number);
+
+      public unreffed: boolean;
+      public listener: (...args: any[]) => void;
+      public after: number;
+
+      public unref(): void;
+      public start(): void;
+      public close(): void;
+      public ref(): void;
+    }
+
+    export class Interval {
+      constructor(listener: (...args: any[]) => void, after: number);
+
+      public unreffed: boolean;
+      public listener: (...args: any[]) => void;
+      public after: number;
+
+      public unref(): void;
+      public start(): void;
+      public close(): void;
+      public ref(): void;
+    }
+  }
+
+  export = LongTimeout;
+}

--- a/src/structures/managers/TimeoutsManager.ts
+++ b/src/structures/managers/TimeoutsManager.ts
@@ -3,7 +3,7 @@ import { Punishment, PunishmentType } from './PunishmentManager';
 import { Guild } from 'eris';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../../types';
-import { bigTimeout } from '../../util';
+import { setTimeout } from 'long-timeout';
 import ms from 'ms';
 
 /**
@@ -21,7 +21,7 @@ export default class TimeoutsManager {
   }
 
   private createTimeout(key: string, task: string, member: string, guild: Guild, time: number) {
-    return bigTimeout(async () => {
+    return setTimeout(async () => {
       if (await this.bot.redis.hexists('timeouts', key)) {
         try {
           await this.bot.punishments.punish(

--- a/src/util/Utilities.test.ts
+++ b/src/util/Utilities.test.ts
@@ -59,41 +59,6 @@ describe('Utilities', () => {
     expect(embed).toStrictEqual(strings.join('\n'));
   });
 
-  it('should test bigTimeout with a 1 minute timeout', () => {
-    const MINUTE = 60000;
-    const callback = jest.fn(); // Creates a mock function
-
-    util.bigTimeout(callback, MINUTE);
-    expect(callback).not.toBeCalled();
-
-    jest.advanceTimersByTime(60000);
-    expect(callback).toBeCalled();
-    expect(callback).toHaveBeenCalledTimes(1);
-  });
-
-  it('should test bigTimeout with a 1 year timeout', () => {
-    const YEAR = 31557600000;
-    let temp = YEAR;
-    const callback = jest.fn();
-  
-    util.bigTimeout(callback, YEAR);
-    expect(callback).not.toBeCalled();
-
-    let i = 0;
-    while (temp > 0x7fffffff) {
-      jest.advanceTimersByTime(0x7fffffff);
-      temp -= 0x7fffffff;
-      i++;
-    }
-    jest.runOnlyPendingTimers();
-
-    expect(i).toBe(Math.floor(YEAR / 0x7fffffff));
-    expect(jest.getTimerCount()).toBe(0);
-    expect(0x7fffffff*i + temp).toBe(YEAR);
-    expect(callback).toBeCalled();
-    expect(callback).toHaveBeenCalledTimes(1);
-  });
-
   it('should return "Ban" when converting to "ban"', () =>
     expect(util.firstUpper('ban')).toBe('Ban')
   );

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -89,19 +89,6 @@ export function unembedify(embed: EmbedOptions) {
   return text;
 }
 
-/**
- * The setTimeout function for big time values.
- * @param func the function to execute
- * @param time the time to excute it after
- */
-export function bigTimeout(func: (...args: any[]) => void, time: number) {
-  if (time > 0x7fffffff) {
-    setTimeout(() => bigTimeout(func, time - 0x7fffffff), 0x7fffffff);
-  } else {
-    setTimeout(func, time);
-  }
-}
-
 export function firstUpper(text: string) {
   const arr = text.split(' ');
   return arr.map((t) => `${t.charAt(0).toUpperCase()}${t.slice(1)}`).join(' ');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "noImplicitAny": false,
     "moduleResolution": "node",
-    "types": ["node", "jest"],
+    "types": ["node", "@types/jest"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "typeRoots": ["./src/@types"]
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
- Fix the huge bug of spawning in `bigTimeout`, by opting to use [long-timeout](https://npm.im/long-timeout)
- Update dependencies